### PR TITLE
Update v5-0-26-to-v5-0-41.md

### DIFF
--- a/migration/v5-0-26-to-v5-0-41.md
+++ b/migration/v5-0-26-to-v5-0-41.md
@@ -632,6 +632,9 @@ public void ConfigureServices(IServiceCollection services)
         //...
         typeof(Serenity.Pro.Extensions.BackgroundJobManager).Assembly,
     }
+    
+     //...
+   services.AddExcelExporter();
 }
 ```
 


### PR DESCRIPTION
In the Add Serenity.Extensions Package Reference of [https://serenity.is/docs/migration/v5-0-26-to-v5-0-41](url) a call to services.AddExcelExporter() was missing, causing an error

> InvalidOperationException: Unable to resolve service for type 'Serenity.Reporting.IDataReportExcelRenderer' while attempting to activate 'Serenity.Extensions.Pages.ReportController'.

In the documentation it only state that typeof(Serenity.Extensions.EnvironmentSettings).Assembly should be added

```
public void ConfigureServices(IServiceCollection services)
{
    services.AddSingleton<ITypeSource>(new DefaultTypeSource(new[] 
    {
        //...
        typeof(Serenity.Extensions.EnvironmentSettings).Assembly,
    }
}
```
When it should be

```
public void ConfigureServices(IServiceCollection services)
{
    services.AddSingleton<ITypeSource>(new DefaultTypeSource(new[] 
    {
        //...
        typeof(Serenity.Extensions.EnvironmentSettings).Assembly,
    }

   //...
   services.AddExcelExporter();
}
```

adding a call to services.AddExcelExporter() service extension